### PR TITLE
Fix error_code_id

### DIFF
--- a/opennav_docking_bt/include/opennav_docking_bt/dock_robot.hpp
+++ b/opennav_docking_bt/include/opennav_docking_bt/dock_robot.hpp
@@ -96,7 +96,7 @@ public:
         BT::OutputPort<ActionResult::_success_type>(
           "success", "If the action was successful"),
         BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code", "Error code"),
+          "error_code_id", "Error code"),
         BT::OutputPort<ActionResult::_num_retries_type>(
           "num_retries", "The number of retries executed"),
       });

--- a/opennav_docking_bt/include/opennav_docking_bt/undock_robot.hpp
+++ b/opennav_docking_bt/include/opennav_docking_bt/undock_robot.hpp
@@ -89,7 +89,7 @@ public:
         BT::OutputPort<ActionResult::_success_type>(
           "success", "If the action was successful"),
         BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code", "Error code"),
+          "error_code_id", "Error code"),
       });
   }
 };


### PR DESCRIPTION
At one place in both the dock and undock BT node declarations it's written `error_code` instead of `error_code_id`. This fixes the error codes not getting set in the navigator.