### PR TITLE
Export pose_filter and plugins

### DIFF
--- a/opennav_docking/CMakeLists.txt
+++ b/opennav_docking/CMakeLists.txt
@@ -129,6 +129,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(${library_name})
+ament_export_libraries(${library_name} pose_filter)
 ament_export_dependencies(${dependencies})
 ament_package()

--- a/opennav_docking/package.xml
+++ b/opennav_docking/package.xml
@@ -33,5 +33,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <opennav_docking plugin="${prefix}/plugins.xml" />
   </export>
 </package>


### PR DESCRIPTION
Same as https://github.com/ros-navigation/navigation2/pull/4413.

The main reason is that it can be backported to humble as there isn't a nav2 version of the docking in humble branch.