### PR TITLE
Fix - add base_frame param to SimpleChargingDock

### DIFF
--- a/opennav_docking/include/opennav_docking/simple_charging_dock.hpp
+++ b/opennav_docking/include/opennav_docking/simple_charging_dock.hpp
@@ -142,6 +142,7 @@ protected:
   double charging_threshold_;
   // If not using an external pose reference, this is the distance threshold
   double docking_threshold_;
+  std::string base_frame_id_;
   // Offset for staging pose relative to dock pose
   double staging_x_offset_;
   double staging_yaw_offset_;

--- a/opennav_docking/src/simple_charging_dock.cpp
+++ b/opennav_docking/src/simple_charging_dock.cpp
@@ -96,6 +96,7 @@ void SimpleChargingDock::configure(
   node_->get_parameter(name + ".docking_threshold", docking_threshold_);
   node_->get_parameter(name + ".staging_x_offset", staging_x_offset_);
   node_->get_parameter(name + ".staging_yaw_offset", staging_yaw_offset_);
+  node_->get_parameter("base_frame", base_frame_id_);  // Get server base frame ID
 
   // Setup filter
   double filter_coef;
@@ -250,7 +251,7 @@ bool SimpleChargingDock::isDocked()
   // Find base pose in target frame
   geometry_msgs::msg::PoseStamped base_pose;
   base_pose.header.stamp = rclcpp::Time(0);
-  base_pose.header.frame_id = "base_link";
+  base_pose.header.frame_id = base_frame_id_;
   base_pose.pose.orientation.w = 1.0;
   try {
     tf2_buffer_->transform(base_pose, base_pose, dock_pose_.header.frame_id);


### PR DESCRIPTION
Change "base_link" on Simple Charging Dock plugin to base_frame param