### PR TITLE
Set pose_topic for FollowObject goal message

### DIFF
--- a/opennav_following_demo/demo.py
+++ b/opennav_following_demo/demo.py
@@ -58,6 +58,7 @@ class FollowObjectTester(Node):
             self.get_logger().info('"FollowObject" action server not available, waiting...')
 
         goal_msg = FollowObject.Goal()
+        goal_msg.pose_topic = '/detected_dynamic_pose'
         future = self.follow_action_client.send_goal_async(
             goal_msg, feedback_callback=self.action_feedback_callback)
         self.goal_handle = future.result()


### PR DESCRIPTION
Set goal_msg.pose_topic to '/detected_dynamic_pose' so it is sent to server properly, as per [bug #90 ](https://github.com/issues/recent?issue=open-navigation%7Copennav_docking%7C90).